### PR TITLE
fix(run_ingest): Use dictionary key to access run ID

### DIFF
--- a/src/email_assistant/tools/gmail/run_ingest.py
+++ b/src/email_assistant/tools/gmail/run_ingest.py
@@ -166,7 +166,7 @@ async def ingest_email_to_langgraph(email_data, graph_name, url="http://127.0.0.
             
             # Delete all previous runs to avoid state accumulation
             for run_info in runs:
-                run_id = run_info.id
+                run_id = run_info["run_id"]
                 print(f"Deleting previous run {run_id} from thread {thread_id}")
                 try:
                     await client.runs.delete(thread_id, run_id)


### PR DESCRIPTION
The `client.runs.list` method returns a list of dictionaries, where each dictionary represents a run. The previous code attempted to access the run ID using attribute access (`run_info.id`), which caused an `AttributeError` because dictionaries do not have attributes.

This commit changes the access method to use the correct dictionary key (`run_info["run_id"]`) to retrieve the run ID. This resolves the bug that occurred when cleaning up previous runs from a thread, allowing the email ingestion process to complete successfully.