### PR TITLE
Add dotenv loading to Gmail ingestion scripts

### DIFF
--- a/src/email_assistant/tools/gmail/run_ingest.py
+++ b/src/email_assistant/tools/gmail/run_ingest.py
@@ -18,6 +18,9 @@ from datetime import datetime
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from langgraph_sdk import get_client
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Setup paths
 _ROOT = Path(__file__).parent.absolute()

--- a/src/email_assistant/tools/gmail/setup_cron.py
+++ b/src/email_assistant/tools/gmail/setup_cron.py
@@ -10,6 +10,10 @@ import argparse
 import asyncio
 from typing import Optional
 from langgraph_sdk import get_client
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
 
 async def main(
     email: str,


### PR DESCRIPTION
- Add python-dotenv import and load_dotenv() call to run_ingest.py
- Add python-dotenv import and load_dotenv() call to setup_cron.py

I had to add `load_dotenv()` to load local `.env` variables when running the email ingestion in [step 2](https://github.com/langchain-ai/agents-from-scratch/tree/main/src/email_assistant/tools/gmail#2-run-ingestion-with-hosted-deployment) and the cron job in [step 4](https://github.com/langchain-ai/agents-from-scratch/tree/main/src/email_assistant/tools/gmail#4-set-up-cron-job).