### PR TITLE
bugfix: Error sending email

### DIFF
--- a/src/email_assistant/tools/gmail/gmail_tools.py
+++ b/src/email_assistant/tools/gmail/gmail_tools.py
@@ -558,10 +558,13 @@ def send_email(
             subject = "Response"
             original_from = "recipient@example.com"  # Will be overridden by user input
             thread_id = None
+
+        # Parse the email address from the From header (which may contain name)
+        parsed_from = email.utils.parseaddr(original_from)[1]  # Extract just the email address
             
         # Create a message object
         msg = MIMEText(response_text)
-        msg["to"] = original_from
+        msg["to"] = parsed_from
         msg["from"] = email_address
         msg["subject"] = subject
         


### PR DESCRIPTION
Error sending email: <HttpError 400 when requesting https://gmail.googleapis.com/gmail/v1/users/me/messages/send?alt=json returned "Invalid To header". Details: "[{'message': 'Invalid To header', 'domain': 'global', 'reason': 'invalidArgument'}]">