### PR TITLE
Fix: use json_schema method in with_structured_output for Groq

### DIFF
--- a/src/email_assistant/email_assistant.py
+++ b/src/email_assistant/email_assistant.py
@@ -19,7 +19,7 @@ tools_by_name = get_tools_by_name(tools)
 
 # Initialize the LLM for use with router / structured output
 llm = init_chat_model("openai:gpt-4.1", temperature=0.0)
-llm_router = llm.with_structured_output(RouterSchema) 
+llm_router = llm.with_structured_output(RouterSchema, method="json_schema") 
 
 # Initialize the LLM, enforcing tool use (of any available tools) for agent
 llm = init_chat_model("openai:gpt-4.1", temperature=0.0)


### PR DESCRIPTION
Specify method="json_schema" in with_structured_output to avoid tool calling validation errors. This allows Groq to return structured output directly without attempting to call an unregistered tool.